### PR TITLE
Change word ordering in carousel section

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@ layout: landing
 						<div class="inner">
 							<header class="major">
 								<h2>The Solar System Exploration Group is the lab group of<br />
-								Dr. Rebecca Ghent. We study the physical properties and<br />
-                                processes of the inner solar system.</h2>
+								Dr. Rebecca Ghent. We study the physical properties<br />
+                                and processes of the inner solar system.</h2>
 								<p>Aliquam ut ex ut augue consectetur interdum. Donec amet imperdiet eleifend<br />
 								fringilla tincidunt. Nullam dui leo Aenean mi ligula, rhoncus ullamcorper.</p>
 							</header>


### PR DESCRIPTION
I changed one word so the carousel title text would line up on three lines.